### PR TITLE
Fix recover account

### DIFF
--- a/web-app/src/api/index.js
+++ b/web-app/src/api/index.js
@@ -28,6 +28,10 @@ export default {
                     restApi.config({keys})
                     return Promise.resolve(keys)
                 })
+                .then(async(keys)=>{
+                    const account = await restApi.accounts.get(keys.publicKey)
+                    return Promise.resolve({...keys, account })
+                })
         }
     },
     reports: {

--- a/web-app/src/api/index.js
+++ b/web-app/src/api/index.js
@@ -1,4 +1,4 @@
-import keyManager  from './keyManager';
+import keyManager, { saveCredentials }  from './keyManager';
 import restApi from './restApi'
 import socketApi from './socketApi'
 
@@ -22,7 +22,7 @@ export default {
         set: restApi.accounts.set,
         get: restApi.accounts.get,
         list: restApi.accounts.list,
-        recover: (words) => {
+        recover: (words, forceCredentials) => {
             return keyManager.regenerate(words)
                 .then((keys)=>{
                     restApi.config({keys})
@@ -30,7 +30,11 @@ export default {
                 })
                 .then(async(keys)=>{
                     const account = await restApi.accounts.get(keys.publicKey)
-                    return Promise.resolve({...keys, account })
+                    if(!account.username || forceCredentials ) {
+                        return Promise.resolve({...keys, account, verified: false})
+                    }
+                    saveCredentials(keys)
+                    return Promise.resolve({...keys, account, verified: true })
                 })
         }
     },

--- a/web-app/src/api/keyManager.js
+++ b/web-app/src/api/keyManager.js
@@ -23,11 +23,14 @@ const generate = (words) => {
     }
 }
 
+export const saveCredentials = (credentials) => {
+    localStorage.setItem('credentials', JSON.stringify(credentials))
+}
+
 const regenerate = (words) => {
     return new Promise((res, rej) => {
         try {
             const credentials = generate(words)
-            localStorage.setItem('credentials', JSON.stringify(credentials))
             res(credentials)
         } catch(e) {
             rej({error: 'wrong words'})
@@ -45,7 +48,8 @@ const loadOrCreate = () => {
     let credentials = isSaved();
     if (!credentials) {
         credentials = generate();
-        localStorage.setItem('credentials', JSON.stringify(credentials))
+        saveCredentials(credentials)
+
     }
     return credentials;
 }


### PR DESCRIPTION
If the user types some bad character in the word list, ends up with a new identity, completely different from the someone wanted to recover. 
In this pull-request I do a verification of the account checking that the created id already has some previous identity data.
If it doesn't find it it returns the keys and a new field "verified: false". In this case the credentials are not saved in localStorage. 
If you want to use this list of words anyway, you can call api.accounts.generate(words, force) again with force set in "true". That way the credentials are taken as valid anyway.