### PR TITLE
Scan pendrives endpoint

### DIFF
--- a/federated-server/package.json
+++ b/federated-server/package.json
@@ -18,6 +18,7 @@
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "dotenv": "^8.1.0",
+    "drivelist": "^8.0.9",
     "eslint": "^6.5.1",
     "express": "^4.17.1",
     "mime-types": "^2.1.24",

--- a/federated-server/routes/config/index.js
+++ b/federated-server/routes/config/index.js
@@ -1,2 +1,3 @@
 export const { setConfig } = require('./setConfig')
 export const { showForm } = require('./showForm')
+export const { getPendrives } = require('./pendrives')

--- a/federated-server/routes/config/pendrives.js
+++ b/federated-server/routes/config/pendrives.js
@@ -1,11 +1,8 @@
-const fs = require('fs');
+const drivelist = require('drivelist');
 
 export const getPendrives = (req, res) => {
-    fs.readdir('/dev/disk/by-id/', (err, items) => {
-        let usb_devices = items
-            .filter(x => x.startsWith('usb'))
-            .map(x => x.replace('usb-', '').split(':')[0])
-        usb_devices = [...new Set(usb_devices)]
-        res.json(usb_devices);
+    drivelist.list().then(drives => {
+        const usbDrives = drives.filter(d => d.busType=='USB');
+        res.json(usbDrives)
     })
 }

--- a/federated-server/routes/config/pendrives.js
+++ b/federated-server/routes/config/pendrives.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+export const getPendrives = (req, res) => {
+    fs.readdir('/dev/disk/by-id/', (err, items) => {
+        let usb_devices = items
+            .filter(x => x.startsWith('usb'))
+            .map(x => x.replace('usb-', '').split(':')[0])
+        usb_devices = [...new Set(usb_devices)]
+        res.json(usb_devices);
+    })
+}

--- a/federated-server/sever-fbw.js
+++ b/federated-server/sever-fbw.js
@@ -1,8 +1,9 @@
-import { showForm, setConfig } from './routes/config';
+import { showForm, setConfig, getPendrives } from './routes/config';
 import { getServers } from './routes/network/getServers';
 
 export const runFirstRunWizardServer = (app) => {
     app.get('/servers', getServers)
+    app.get('/pendrives', getPendrives)
     app.get('/*', showForm)
     app.post('/*', setConfig)
     ///////////////////////////////////////////////////////


### PR DESCRIPTION
Scan pendrives using drivelist lib. The returned data for each drive includes the mountpoint and a description which allows to recognize the device

closes https://github.com/LibreRouterOrg/soporteremoto/issues/10