### PR TITLE
Pendrives scan and certificate copy

### DIFF
--- a/federated-server/app.js
+++ b/federated-server/app.js
@@ -1,0 +1,16 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json())
+
+///////////////////////////////////////////////////////
+//Enable cors
+///////////////////////////////////////////////////////
+app.use(function (req, res, next) {
+    // TODO: update to match the domain you will make the request from
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
+});
+
+export default app;

--- a/federated-server/babel.config.js
+++ b/federated-server/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    presets: [
+        [
+            '@babel/preset-env',
+            {
+                targets: {
+                    node: 'current',
+                },
+            },
+        ],
+    ],
+};

--- a/federated-server/config.js
+++ b/federated-server/config.js
@@ -61,3 +61,14 @@ export const loadOrCreateConfig = async() => {
     return config;
 }   
 
+export const getPublicCertificate = async() => {
+    const config = await loadOrCreateConfig();
+    if (!('certificates' in config)) {
+        return undefined;
+    }
+    const certificates = config['certificates'];
+    if (!('pubCert' in config)) {
+        return undefined;
+    }
+    return certificates['pubCert'];
+}

--- a/federated-server/index.js
+++ b/federated-server/index.js
@@ -1,31 +1,14 @@
-import  express  from 'express'
-
 import { runFirstRunWizardServer } from './sever-fbw';
 import { runFullServer } from './server-full';
 const { DEPLOYED } = process.env;
-
-///////////////////////////////////////////////////////
-//Setup http server
-///////////////////////////////////////////////////////
-const app = express()
-app.use(express.json())
-
-///////////////////////////////////////////////////////
-//Enable cors
-///////////////////////////////////////////////////////
-app.use(function(req, res, next) {
-    res.header("Access-Control-Allow-Origin", "*"); // update to match the domain you will make the request from
-    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    next();
-  });
 
 ///////////////////////////////////////////////////////
 //Setup server
 ///////////////////////////////////////////////////////
 
 if(!DEPLOYED){
-  runFirstRunWizardServer(app)
+  runFirstRunWizardServer()
 } else {
-  runFullServer(app)
+  runFullServer()
 }
 

--- a/federated-server/package.json
+++ b/federated-server/package.json
@@ -18,6 +18,7 @@
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "dotenv": "^8.1.0",
+    "drivelist": "^8.0.9",
     "eslint": "^6.5.1",
     "express": "^4.17.1",
     "mime-types": "^2.1.24",

--- a/federated-server/package.json
+++ b/federated-server/package.json
@@ -5,7 +5,7 @@
   "main": "run.js",
   "scripts": {
     "start": "node run.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "libremesh",
@@ -54,7 +54,13 @@
     "uuid": "^3.3.3"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.7.4",
+    "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "babel-register": "^6.26.0"
+    "babel-register": "^6.26.0",
+    "jest": "^24.9.0",
+    "mock-fs": "^4.10.4",
+    "superagent": "^5.1.2",
+    "supertest": "^4.0.2"
   }
 }

--- a/federated-server/routes/config/index.js
+++ b/federated-server/routes/config/index.js
@@ -1,2 +1,3 @@
 export const { setConfig } = require('./setConfig')
 export const { showForm } = require('./showForm')
+export const { getPendrives } = require('./pendrives')

--- a/federated-server/routes/config/index.js
+++ b/federated-server/routes/config/index.js
@@ -1,3 +1,2 @@
 export const { setConfig } = require('./setConfig')
-export const { showForm } = require('./showForm')
-export const { getPendrives } = require('./pendrives')
+export const { getPendrives, copyCertificate } = require('./pendrives')

--- a/federated-server/routes/config/pendrives.js
+++ b/federated-server/routes/config/pendrives.js
@@ -1,8 +1,32 @@
+import { getPublicCertificate } from '../../config';
+const fs = require('fs');
+const path = require('path');
 const drivelist = require('drivelist');
 
 export const getPendrives = (req, res) => {
-    drivelist.list().then(drives => {
-        const usbDrives = drives.filter(d => d.busType=='USB');
-        res.json(usbDrives)
+    getUsbDrives().then(drives => res.json(drives));
+}
+
+export const copyCertificate = async (req, res) => {
+    // Read certificate
+    const pubCert = await getPublicCertificate();
+    if (!pubCert) {
+        res.json({ 'error': 'pubCert was not found at config' });
+        return;
+    }
+    // Search for usb device
+    let device = null;
+    let deviceName = req.body.device;
+    getUsbDrives().then(drives => {
+        drives = drives.filter(d => d.device === deviceName);
+        if (drives.length == 0) {
+            res.json({ 'error': 'device ' + deviceName + ' was not found' });
+            return;
+        }
+        device = drives[0];
+        const mountpointPath = device.mountpoints[0].path;
+        const certPath = path.join(mountpointPath, 'pubCert');
+        fs.writeFileSync(certPath, pubCert);
+        res.json({ 'message': 'pubCert successfully copied to ' + deviceName })
     })
 }

--- a/federated-server/routes/config/pendrives.js
+++ b/federated-server/routes/config/pendrives.js
@@ -3,6 +3,11 @@ const fs = require('fs');
 const path = require('path');
 const drivelist = require('drivelist');
 
+const getUsbDrives = async () => {
+    const drives = await drivelist.list();
+    return drives.filter(d => d.busType === 'USB');
+}
+
 export const getPendrives = (req, res) => {
     getUsbDrives().then(drives => res.json(drives));
 }

--- a/federated-server/routes/config/pendrives.js
+++ b/federated-server/routes/config/pendrives.js
@@ -1,11 +1,8 @@
-const fs = require('fs');
+const drivelist = require('drivelist');
 
 export const getPendrives = (req, res) => {
-    fs.readdir('/dev/disk/by-id/', (err, items) => {
-        let usb_devices = items
-            .filter(x => x.startsWith('usb'))
-            .map(x => x.replace('usb-', '').split(':')[0])
-        usb_devices = [...new Set(usb_devices)]
-        res.json(usb_devices);
+    drivelist.list().then(drives => {
+        const usbDrives = drives.filter(d => d.busType=='USB');
+        res.json(usbDrives)
     })
 }

--- a/federated-server/routes/config/pendrives.js
+++ b/federated-server/routes/config/pendrives.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+export const getPendrives = (req, res) => {
+    fs.readdir('/dev/disk/by-id/', (err, items) => {
+        let usb_devices = items
+            .filter(x => x.startsWith('usb'))
+            .map(x => x.replace('usb-', '').split(':')[0])
+        usb_devices = [...new Set(usb_devices)]
+        res.json(usb_devices);
+    })
+}

--- a/federated-server/routes/config/pendrives.test.js
+++ b/federated-server/routes/config/pendrives.test.js
@@ -1,0 +1,89 @@
+const request = require('supertest');
+const drivelist = require('drivelist');
+import app from '../../app';
+import { setupFirstRunWizardApp } from '../../sever-fbw';
+const mockFs = require('mock-fs');
+const fs = require('fs');
+setupFirstRunWizardApp(app)
+
+
+describe('getPendrives', () => {
+    test('It should return only USB drives', () => {
+        const pendrive = {
+            "busType": "USB",
+            "device": "/dev/sdb",
+            "description": "My Pendrive",
+            "mountpoints": [{ "path": "/mnt/my-pendrive" }],
+        }
+        const primaryDisk = {
+            "busType": "SATA",
+            "device": "/dev/sda",
+            "description": "My primary disk",
+            "mountpoints": [{ "path": "/" }],
+        }
+        drivelist.list = jest.fn().mockReturnValue([pendrive, primaryDisk]);
+        return request(app).get('/pendrives').then((response) => {
+            expect(JSON.stringify(response.body)).toBe(JSON.stringify([pendrive]));
+        });
+    });
+});
+
+describe('copyCertificate', () => {
+    test('It should return error when the certificate is not configured', () => {
+        jest.unmock('../../config');
+        const config = require('../../config');
+        config.getPublicCertificate = jest.fn().mockReturnValue(undefined);
+        return request(app)
+            .post('/copy-certificate')
+            .send({ device: '/dev/sdb' })
+            .set('Accept', 'application/json')
+            .then(response => {
+                // console.log(response)
+                expect(response.body.error).toBe('pubCert was not found at config');
+            })
+    });
+
+    test('It should return error when the requested device is not present', () => {
+        jest.unmock('../../config');
+        const config = require('../../config');
+        config.getPublicCertificate = jest.fn().mockReturnValue('this-is-the-pubCert');
+        drivelist.list = jest.fn().mockReturnValue([{
+            "busType": "USB",
+            "device": "/dev/sdb",
+            "description": "My Pendrive",
+            "mountpoints": [{ "path": "/mnt/my-pendrive" }]
+        }]);
+        return request(app)
+            .post('/copy-certificate')
+            .send({ device: '/dev/sdc' })
+            .set('Accept', 'application/json')
+            .then(response => {
+                // console.log(response)
+                expect(response.body.error).toBe('device /dev/sdc was not found');
+            })
+    });
+
+    test('It should create the file into the first mountpoint of the device', () => {
+        jest.unmock('../../config');
+        const config = require('../../config');
+        config.getPublicCertificate = jest.fn().mockReturnValue('this-is-the-pubCert');
+        drivelist.list = jest.fn().mockReturnValue([{
+            "busType": "USB",
+            "device": "/dev/sdb",
+            "description": "My Pendrive",
+            "mountpoints": [{ "path": "/mnt/my-pendrive" }, { "path": "/mnt/my-pendrive-2" }]
+        }]);
+        mockFs({
+            "/mnt/my-pendrive": {/* empty dir */}
+        })
+        return request(app)
+            .post('/copy-certificate')
+            .send({ device: '/dev/sdb' })
+            .set('Accept', 'application/json')
+            .then(response => {
+                expect(fs.readFileSync('/mnt/my-pendrive/pubCert', {encoding: 'utf8'})).toBe('this-is-the-pubCert');
+                expect(response.body.message).toBe('pubCert successfully copied to /dev/sdb');
+                mockFs.restore();
+            })
+    });
+})

--- a/federated-server/server-full.js
+++ b/federated-server/server-full.js
@@ -12,9 +12,10 @@ import pull from 'pull-stream'
 import schedule  from 'node-schedule';
 import { getActualNodes } from './shared-state';
 import { sendNodesToDb } from './schedule/nodes';
-import path from 'path'
+import path from 'path';
+import app from './app';
 
-export const runFullServer = (app) => {
+export const runFullServer = () => {
     ///////////////////////////////////////////////////////
     //Start ssb
     ///////////////////////////////////////////////////////

--- a/federated-server/sever-fbw.js
+++ b/federated-server/sever-fbw.js
@@ -1,11 +1,19 @@
-import { showForm, setConfig, getPendrives } from './routes/config';
+import { setConfig, getPendrives, copyCertificate} from './routes/config';
 import { getServers } from './routes/network/getServers';
+import express from 'express'
+import app from './app';
 
-export const runFirstRunWizardServer = (app) => {
+export const setupFirstRunWizardApp = (app) => {
     app.get('/servers', getServers)
     app.get('/pendrives', getPendrives)
-    app.get('/*', showForm)
+    app.post('/copy-certificate', copyCertificate)
+    app.post('/set-config', setConfig)
     app.post('/*', setConfig)
+    app.use(express.static('routes/config/statics'))
+}
+
+export const runFirstRunWizardServer = () => {
+    setupFirstRunWizardApp(app)
     ///////////////////////////////////////////////////////
     //Start first boot server
     ///////////////////////////////////////////////////////

--- a/federated-server/sever-fbw.js
+++ b/federated-server/sever-fbw.js
@@ -1,8 +1,9 @@
-import { showForm, setConfig } from './routes/config';
+import { showForm, setConfig, getPendrives } from './routes/config';
 import { getServers } from './routes/network/getServers';
 
 export const runFirstRunWizardServer = (app) => {
     app.get('/servers', getServers)
+    app.get('/pendrives', getPendrives)
     app.get('/*', showForm)
     app.post('/*', setConfig)
     ///////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds two endpoints.
/pendrives
/copy-certificate
which together handle back-end logic for copying the public certificate to a plugged usb device

closes https://github.com/LibreRouterOrg/soporteremoto/issues/10
closes https://github.com/LibreRouterOrg/soporteremoto/issues/11