### PR TITLE
Send request support to tier

### DIFF
--- a/federated-server/.gitignore
+++ b/federated-server/.gitignore
@@ -65,6 +65,7 @@ yarn.lock
 
 # ssb config
 .config.json
+.passwords.json
 
 # support config
 toSend.json

--- a/federated-server/config.js
+++ b/federated-server/config.js
@@ -12,6 +12,24 @@ export const saveConfig = (config={}) => {
     }
 }
 
+export const savePasswords = ({apiKey, password}) => {
+    try {
+        fs.writeFileSync('.passwords.json', JSON.stringify({apiKey, password}, null, '  '), { encoding: 'utf8'});
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+export const getPasswords = () => {
+    try {
+        const rawdata = fs.readFileSync('.passwords.json', { encoding: 'utf8' });
+        return JSON.parse(rawdata);
+    } catch (e) {
+        return;
+    }
+}
+
 export const getConfig = () => {
     if(process.env.REMOTE_CONTAINER) {
         return {

--- a/federated-server/package.json
+++ b/federated-server/package.json
@@ -22,6 +22,7 @@
     "drivelist": "^8.0.9",
     "eslint": "^6.5.1",
     "express": "^4.17.1",
+    "ip": "^1.1.5",
     "mime-types": "^2.1.24",
     "multiserver-address": "^1.0.1",
     "node-fetch": "^2.6.0",

--- a/federated-server/routes/config/setConfig.js
+++ b/federated-server/routes/config/setConfig.js
@@ -73,7 +73,7 @@ export const setConfig = async (req, res) => {
 
         try {
           console.log('Sending to support endpoint', process.env.SUPPORT_ENDPOINT)
-          const supportsubscription = await fetch(process.env.SUPPORT_ENDPOINT, {
+          const supportsubscription = await fetch(process.env.SUPPORT_ENDPOINT+'/submit', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: toSend

--- a/federated-server/routes/config/setConfig.js
+++ b/federated-server/routes/config/setConfig.js
@@ -1,6 +1,6 @@
 import { makePasswd } from "../../utils/makePassword"
 import { getSbot } from "../../db"
-import { loadOrCreateConfig, saveConfig } from "../../config"
+import { loadOrCreateConfig, saveConfig, savePasswords } from "../../config"
 import { writeSecretBox, formPrivate, writePublic } from "../../utils/signify"
 import fs from 'fs';
 import os from 'os';
@@ -42,7 +42,8 @@ export const setConfig = async (req, res) => {
     };
 
     saveConfig(Object.assign(config, { certificates }))
-
+    savePasswords({ apiKey: req.body.apiKey, password })
+    
     getSbot(async (sbot)=> {
       const certificates = Object.assign({action: 'enable', certificates })
       sbot.publish({
@@ -53,7 +54,7 @@ export const setConfig = async (req, res) => {
       }, async() => {
         if(!req.body.apiKey) return res.json({password, certificates});
         const toSend = JSON.stringify({
-          apiKey: 'BqlmHSxkI8K5',
+          apiKey: req.body.apiKey,
           config: {
             device: {
               name: os.hostname(),

--- a/federated-server/routes/supportRequests/create.js
+++ b/federated-server/routes/supportRequests/create.js
@@ -1,6 +1,41 @@
-import { getSbotAsPromise } from "../../db";
-import { orderLog } from "../../utils/orderLog";
-import { getStatus } from "./enrich";
+import { getSbotAsPromise } from "../../db"
+import { orderLog } from "../../utils/orderLog"
+import { getStatus } from "./enrich"
+import ip from 'ip'
+import { getPasswords, loadOrCreateConfig } from "../../config"
+import fetch from 'node-fetch'
+import { signAndSaveKey } from "../keys/addKey"
+
+const sendRequestToTier = async (supportRequest) => {
+    const { apiKey, password } = getPasswords()
+    const ln6Ip = ip.address('librenet6', "ipv6")
+    const sbot = await getSbotAsPromise()
+    const {network, certificates } = await loadOrCreateConfig()
+
+    const toSend = {
+        request: {
+            librenet6: {
+                ip: ln6Ip,
+                public: ip.isPublic(ln6Ip)
+            },
+            issue: supportRequest
+        },
+        apiKey
+    }
+
+    let {error, sshKey, name} = await fetch(process.env.SUPPORT_ENDPOINT+'/support-request', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(toSend)
+    }).then(res => res.json())
+
+    console.log({error, sshKey, name})
+    if (error) throw Error(error);
+
+    const added = await signAndSaveKey({ password, sshKey, name, action: 'add'}, { network, certificates }, sbot)
+    console.log('\n\n\n\n\n\n\n',added)
+    return;
+}
 
 export const createSupportRequest = async (req, res) => {
     /*
@@ -11,9 +46,17 @@ export const createSupportRequest = async (req, res) => {
         const supportRequestData = orderLog(req.body);
         if (supportRequestData)
             sbot.add(supportRequestData,
-                async (err, supportRequest) => {
-                    supportRequest.value.content.status = await getStatus(sbot)(supportRequest.key);
-                    return res.json({ err, supportRequest });
+                async (error, supportRequest) => {
+                    if (error) return res.json({ error })
+                    try {
+                        await sendRequestToTier(supportRequest)
+                    }
+                    catch (e) {
+                        console.log('Error sending support request',    e)
+                        error = 'Error sending support request'
+                    }
+                    supportRequest.value.content.status = await getStatus(sbot)(supportRequest.key)
+                    return res.json({ error, supportRequest })
                 })
     } catch (error) {
         res.json({ error })

--- a/federated-server/schedule/resendToSupport.js
+++ b/federated-server/schedule/resendToSupport.js
@@ -5,7 +5,7 @@ export async function resendToSupport(){
     try {
         let json = fs.readFileSync('./toSend.json', { encoding: 'utf8'})
         console.log(json)
-        const response = await fetch(process.env.SUPPORT_ENDPOINT, {
+        const response = await fetch(process.env.SUPPORT_ENDPOINT+'/submit', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: json

--- a/federated-server/utils/signify.js
+++ b/federated-server/utils/signify.js
@@ -121,6 +121,7 @@ export const signKey = (secretKey, keyToSign='') => {
     const signature = nacl.sign(decodeUTF8(keyToSign), secretKey)
     return {
         key: keyToSign,
-        signature: encodeBase64(signature)
+        signature: encodeBase64(uintSized(signature,64)),
+        using: writeSignature(signature, true)
     }
 }

--- a/federated-server/utils/signify.js
+++ b/federated-server/utils/signify.js
@@ -56,11 +56,25 @@ export const readSignature = (signature, asString=false) => {
     }
 }
 
-export const checkSignature = (msg='', signature='', pKey='') => {
-    msg = Uint8Array.from(decodeUTF8(msg))
-    signature = Uint8Array.from(readSignature(signature).sig)
-    pKey = Uint8Array.from(readPublic(pKey).publkey)
-    return nacl.sign.detached.verify(msg, signature, pKey)
+export const writeSignature = (signature, asString=false) => {
+    if (typeof signature === 'string') {
+        signature = decodeBase64(signature)
+    }
+    signature = Array.from(signature)
+    
+    const uSignature = [
+        ...PKGALG,
+        ...[0,0,0,0,0,0,0,0],
+        ...signature.splice(0,SIGBYTES)
+    ]
+    return asString? encodeBase64(uSignature): uSignature
+}
+
+export const checkSignature = (msg='', signature='', publicKey='') => {
+    msg = decodeUTF8(msg)
+    signature = decodeBase64(signature)
+    publicKey = Uint8Array.from(readPublic(publicKey).publkey)
+    return nacl.sign.detached.verify(msg, signature, publicKey)
 }
 
 const uintSized = (base=[], size=32) => {


### PR DESCRIPTION
Sends the ip and authentication data to the configured remote support Tier.
In the same dispatch includes the data of the issue.
If the answer is successful, it signs and saves the received SSH key.