### PR TITLE
Fix Shared State timeout implementation

### DIFF
--- a/federated-server/routes/network/getServers.js
+++ b/federated-server/routes/network/getServers.js
@@ -1,9 +1,6 @@
 import { getOnlyServers } from "../../shared-state"
 
 export async function getServers(req, res) {
-    res.setTimeout(4000,()=> {
-        res.json({ error: 'timeout' })
-    })
     try {
         const servers = await getOnlyServers()
         res.json(servers)


### PR DESCRIPTION
This PR modify the way we timeout shared state requests since previous implementation leads to infinite wait of shared state when shared state was not available.